### PR TITLE
[intervals-mcp-server] Fix activity date filtering and MCP Inspector optional params

### DIFF
--- a/src/intervals_mcp_server/api/client.py
+++ b/src/intervals_mcp_server/api/client.py
@@ -117,7 +117,7 @@ def _prepare_request_config(
         headers["Content-Type"] = "application/json"
 
     # Use provided api_key or fall back to global API_KEY
-    key_to_use = api_key if api_key is not None else config.api_key
+    key_to_use = api_key if api_key else config.api_key
     if not key_to_use:
         logger.error("No API key provided for request to: %s", url)
         return (

--- a/src/intervals_mcp_server/tools/activities.py
+++ b/src/intervals_mcp_server/tools/activities.py
@@ -4,7 +4,6 @@ Activity-related MCP tools for Intervals.icu.
 This module contains tools for retrieving and managing athlete activities.
 """
 
-from datetime import datetime, timedelta
 from typing import Any
 
 from intervals_mcp_server.api.client import make_intervals_request
@@ -53,34 +52,30 @@ def _filter_named_activities(activities: list[dict[str, Any]]) -> list[dict[str,
     ]
 
 
-async def _fetch_more_activities(
-    athlete_id: str,
+def _filter_activities_by_date(
+    activities: list[dict[str, Any]],
     start_date: str,
-    api_key: str | None,
-    api_limit: int,
+    end_date: str,
 ) -> list[dict[str, Any]]:
-    """Fetch additional activities from an earlier date range."""
-    oldest_date = datetime.fromisoformat(start_date)
-    older_start_date = (oldest_date - timedelta(days=60)).strftime("%Y-%m-%d")
-    older_end_date = (oldest_date - timedelta(days=1)).strftime("%Y-%m-%d")
+    """Filter activities to only include those within the specified date range.
 
-    if older_start_date >= older_end_date:
-        return []
+    Args:
+        activities: List of activity dictionaries.
+        start_date: Start date in YYYY-MM-DD format (inclusive).
+        end_date: End date in YYYY-MM-DD format (inclusive).
 
-    more_params = {
-        "oldest": older_start_date,
-        "newest": older_end_date,
-        "limit": api_limit,
-    }
-    more_result = await make_intervals_request(
-        url=f"/athlete/{athlete_id}/activities",
-        api_key=api_key,
-        params=more_params,
-    )
-
-    if isinstance(more_result, list):
-        return _filter_named_activities(more_result)
-    return []
+    Returns:
+        Filtered list of activities within the date range.
+    """
+    filtered: list[dict[str, Any]] = []
+    for activity in activities:
+        raw = activity.get("start_date_local") or activity.get("startTime") or activity.get("start_date", "")
+        if not raw:
+            continue
+        activity_date = str(raw)[:10]  # extract YYYY-MM-DD portion
+        if start_date <= activity_date <= end_date:
+            filtered.append(activity)
+    return filtered
 
 
 def _format_activities_response(
@@ -108,10 +103,10 @@ def _format_activities_response(
 
 @mcp.tool()
 async def get_activities(  # pylint: disable=too-many-arguments,too-many-return-statements,too-many-branches,too-many-positional-arguments
-    athlete_id: str | None = None,
-    api_key: str | None = None,
-    start_date: str | None = None,
-    end_date: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
+    start_date: str = "",
+    end_date: str = "",
     limit: int = 10,
     include_unnamed: bool = False,
     compact: bool = True,
@@ -157,16 +152,12 @@ async def get_activities(  # pylint: disable=too-many-arguments,too-many-return-
     if not activities:
         return f"No valid activities found for athlete {athlete_id_to_use} in the specified date range."
 
+    # Filter activities to the requested date range
+    activities = _filter_activities_by_date(activities, start_date, end_date)
+
     # Filter and fetch more if needed
     if not include_unnamed:
         activities = _filter_named_activities(activities)
-
-        # If we don't have enough named activities, try to fetch more
-        if len(activities) < limit:
-            more_activities = await _fetch_more_activities(
-                athlete_id_to_use, start_date, api_key, api_limit
-            )
-            activities.extend(more_activities)
 
     # Limit to requested count
     activities = activities[:limit]
@@ -175,7 +166,7 @@ async def get_activities(  # pylint: disable=too-many-arguments,too-many-return-
 
 
 @mcp.tool()
-async def get_activity_details(activity_id: str, api_key: str | None = None) -> str:
+async def get_activity_details(activity_id: str, api_key: str = "") -> str:
     """Get detailed information for a specific activity from Intervals.icu
 
     Args:
@@ -216,7 +207,7 @@ async def get_activity_details(activity_id: str, api_key: str | None = None) -> 
 
 
 @mcp.tool()
-async def get_activity_intervals(activity_id: str, api_key: str | None = None) -> str:
+async def get_activity_intervals(activity_id: str, api_key: str = "") -> str:
     """Get interval data for a specific activity from Intervals.icu
 
     This endpoint returns detailed metrics for each interval in an activity, including power, heart rate,
@@ -258,8 +249,8 @@ async def get_activity_intervals(activity_id: str, api_key: str | None = None) -
 @mcp.tool()
 async def get_activity_streams(
     activity_id: str,
-    api_key: str | None = None,
-    stream_types: str | None = None,
+    api_key: str = "",
+    stream_types: str = "",
 ) -> str:
     """Get stream data for a specific activity from Intervals.icu
 
@@ -334,7 +325,7 @@ async def get_activity_streams(
 
 
 @mcp.tool()
-async def get_activity_messages(activity_id: str, api_key: str | None = None) -> str:
+async def get_activity_messages(activity_id: str, api_key: str = "") -> str:
     """Get messages (notes/comments) for a specific activity from Intervals.icu
 
     Args:
@@ -369,7 +360,7 @@ async def get_activity_messages(activity_id: str, api_key: str | None = None) ->
 async def add_activity_message(
     activity_id: str,
     content: str,
-    api_key: str | None = None,
+    api_key: str = "",
 ) -> str:
     """Add a message (note/comment) to an activity on Intervals.icu
 

--- a/src/intervals_mcp_server/tools/activities.py
+++ b/src/intervals_mcp_server/tools/activities.py
@@ -4,6 +4,7 @@ Activity-related MCP tools for Intervals.icu.
 This module contains tools for retrieving and managing athlete activities.
 """
 
+from datetime import datetime
 from typing import Any
 
 from intervals_mcp_server.api.client import make_intervals_request
@@ -67,13 +68,22 @@ def _filter_activities_by_date(
     Returns:
         Filtered list of activities within the date range.
     """
+    try:
+        start_dt = datetime.strptime(start_date, "%Y-%m-%d").date()
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d").date()
+    except ValueError:
+        return activities  # Can't filter if boundary dates are invalid
+
     filtered: list[dict[str, Any]] = []
     for activity in activities:
         raw = activity.get("start_date_local") or activity.get("startTime") or activity.get("start_date", "")
         if not raw:
             continue
-        activity_date = str(raw)[:10]  # extract YYYY-MM-DD portion
-        if start_date <= activity_date <= end_date:
+        try:
+            activity_date = datetime.strptime(str(raw)[:10], "%Y-%m-%d").date()
+        except ValueError:
+            continue
+        if start_dt <= activity_date <= end_dt:
             filtered.append(activity)
     return filtered
 

--- a/src/intervals_mcp_server/tools/athlete.py
+++ b/src/intervals_mcp_server/tools/athlete.py
@@ -239,9 +239,9 @@ def _extract_sport_zones(setting: dict[str, Any]) -> dict[str, Any]:
 
 @mcp.tool()
 async def get_athlete_zones(
-    athlete_id: str | None = None,
-    api_key: str | None = None,
-    sport: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
+    sport: str = "",
 ) -> str:
     """
     Get training zone definitions for an athlete from Intervals.icu.

--- a/src/intervals_mcp_server/tools/custom_items.py
+++ b/src/intervals_mcp_server/tools/custom_items.py
@@ -20,8 +20,8 @@ config = get_config()
 
 @mcp.tool()
 async def get_custom_items(
-    athlete_id: str | None = None,
-    api_key: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
 ) -> str:
     """Get custom items (charts, custom fields, zones, etc.) for an athlete from Intervals.icu
 
@@ -58,8 +58,8 @@ async def get_custom_items(
 @mcp.tool()
 async def get_custom_item_by_id(
     item_id: int,
-    athlete_id: str | None = None,
-    api_key: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
 ) -> str:
     """Get detailed information for a specific custom item from Intervals.icu
 
@@ -89,11 +89,11 @@ async def get_custom_item_by_id(
 async def create_custom_item(
     name: str,
     item_type: str,
-    athlete_id: str | None = None,
-    api_key: str | None = None,
-    description: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
+    description: str = "",
     content: dict[str, Any] | None = None,
-    visibility: str | None = None,
+    visibility: str = "",
 ) -> str:
     """Create a new custom item for an athlete on Intervals.icu
 
@@ -113,7 +113,7 @@ async def create_custom_item(
         return error_msg
 
     data: dict[str, Any] = {"name": name, "type": item_type}
-    if description is not None:
+    if description:
         data["description"] = description
     if content is not None:
         if isinstance(content, str):
@@ -122,7 +122,7 @@ async def create_custom_item(
             except json.JSONDecodeError:
                 return "Error: content must be valid JSON when passed as a string."
         data["content"] = content
-    if visibility is not None:
+    if visibility:
         data["visibility"] = visibility
 
     result = await make_intervals_request(
@@ -144,13 +144,13 @@ async def create_custom_item(
 @mcp.tool()
 async def update_custom_item(
     item_id: int,
-    athlete_id: str | None = None,
-    api_key: str | None = None,
-    name: str | None = None,
-    item_type: str | None = None,
-    description: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
+    name: str = "",
+    item_type: str = "",
+    description: str = "",
     content: dict[str, Any] | None = None,
-    visibility: str | None = None,
+    visibility: str = "",
 ) -> str:
     """Update an existing custom item for an athlete on Intervals.icu
 
@@ -171,11 +171,11 @@ async def update_custom_item(
         return error_msg
 
     data: dict[str, Any] = {}
-    if name is not None:
+    if name:
         data["name"] = name
-    if item_type is not None:
+    if item_type:
         data["type"] = item_type
-    if description is not None:
+    if description:
         data["description"] = description
     if content is not None:
         if isinstance(content, str):
@@ -184,7 +184,7 @@ async def update_custom_item(
             except json.JSONDecodeError:
                 return "Error: content must be valid JSON when passed as a string."
         data["content"] = content
-    if visibility is not None:
+    if visibility:
         data["visibility"] = visibility
 
     result = await make_intervals_request(
@@ -206,8 +206,8 @@ async def update_custom_item(
 @mcp.tool()
 async def delete_custom_item(
     item_id: int,
-    athlete_id: str | None = None,
-    api_key: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
 ) -> str:
     """Delete a custom item for an athlete from Intervals.icu
 

--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -89,10 +89,10 @@ async def _delete_events_list(
 
 @mcp.tool()
 async def get_events(
-    athlete_id: str | None = None,
-    api_key: str | None = None,
-    start_date: str | None = None,
-    end_date: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
+    start_date: str = "",
+    end_date: str = "",
     compact: bool = True,
 ) -> str:
     """Get events for an athlete from Intervals.icu
@@ -150,8 +150,8 @@ async def get_events(
 @mcp.tool()
 async def get_event_by_id(
     event_id: str,
-    athlete_id: str | None = None,
-    api_key: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
 ) -> str:
     """Get detailed information for a specific event from Intervals.icu
 
@@ -187,8 +187,8 @@ async def get_event_by_id(
 @mcp.tool()
 async def delete_event(
     event_id: str,
-    athlete_id: str | None = None,
-    api_key: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
 ) -> str:
     """Delete event for an athlete from Intervals.icu
     Args:
@@ -237,8 +237,8 @@ async def _fetch_events_for_deletion(
 async def delete_events_by_date_range(
     start_date: str,
     end_date: str,
-    athlete_id: str | None = None,
-    api_key: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
 ) -> str:
     """Delete events for an athlete from Intervals.icu in the specified date range.
 
@@ -267,13 +267,13 @@ async def delete_events_by_date_range(
 async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     workout_type: str,
     name: str,
-    athlete_id: str | None = None,
-    api_key: str | None = None,
-    event_id: str | None = None,
-    start_date: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
+    event_id: str = "",
+    start_date: str = "",
     workout_doc: WorkoutDoc | None = None,
-    moving_time: int | None = None,
-    distance: int | None = None,
+    moving_time: int = 0,
+    distance: int = 0,
 ) -> str:
     """Post event for an athlete to Intervals.icu this follows the event api from intervals.icu
     If event_id is provided, the event will be updated instead of created.
@@ -349,7 +349,7 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
 
     try:
         event_data = _prepare_event_data(
-            name, workout_type, start_date, workout_doc, moving_time, distance
+            name, workout_type, start_date, workout_doc, moving_time or None, distance or None
         )
         return await _create_or_update_event_request(
             athlete_id_to_use, api_key, event_data, start_date, event_id

--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -288,8 +288,8 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
         name: Name of the activity
         workout_doc: steps as a list of Step objects (optional, but necessary to define workout steps)
         workout_type: Workout type (e.g. Ride, Run, Swim, Walk, Row)
-        moving_time: Total expected moving time of the workout in seconds (optional)
-        distance: Total expected distance of the workout in meters (optional)
+        moving_time: Total expected moving time of the workout in seconds (optional). Use 0 (default) to omit from the request; 0 will not be transmitted to the API.
+        distance: Total expected distance of the workout in meters (optional). Use 0 (default) to omit from the request; 0 will not be transmitted to the API.
 
     Example:
         "workout_doc": {

--- a/src/intervals_mcp_server/tools/power_curves.py
+++ b/src/intervals_mcp_server/tools/power_curves.py
@@ -55,7 +55,7 @@ def _validate_dates(start_date: str | None, end_date: str | None) -> str | None:
     Returns:
         An error message if validation fails, otherwise None.
     """
-    if (start_date is None) != (end_date is None):
+    if bool(start_date) != bool(end_date):
         return "Error: Both start_date and end_date must be provided together for a custom date range."
     if start_date and end_date:
         try:
@@ -122,13 +122,13 @@ def _extract_curve_data(
 async def get_athlete_power_curves(
     activity_type: str,
     durations: list[int] = DEFAULT_DURATIONS,
-    indoor_outdoor: str | None = None,
-    start_date: str | None = None,
-    end_date: str | None = None,
+    indoor_outdoor: str = "",
+    start_date: str = "",
+    end_date: str = "",
     this_season: bool = True,
     last_season: bool = True,
     include_normalised: bool = True,
-    athlete_id: str | None = None,
+    athlete_id: str = "",
 ) -> str:
     """Get power curves for an athlete from Intervals.icu.
 

--- a/src/intervals_mcp_server/tools/training_summary.py
+++ b/src/intervals_mcp_server/tools/training_summary.py
@@ -461,10 +461,10 @@ def _build_result(
 
 @mcp.tool()
 async def get_training_summary(
-    start_date: str | None = None,
-    end_date: str | None = None,
-    athlete_id: str | None = None,
-    api_key: str | None = None,
+    start_date: str = "",
+    end_date: str = "",
+    athlete_id: str = "",
+    api_key: str = "",
 ) -> str:
     """
     Returns a compact JSON training snapshot for the given date range.

--- a/src/intervals_mcp_server/tools/wellness.py
+++ b/src/intervals_mcp_server/tools/wellness.py
@@ -43,7 +43,8 @@ async def get_wellness_data(
             Valid values: "training", "sport_info", "vital_signs", "sleep",
             "menstrual", "subjective", "nutrition", "activity".
         cadence: Return every Nth day of data (optional). For example, cadence=7
-            returns one entry per week. Must be a positive integer.
+            returns one entry per week. Use 0 (default) to return all entries
+            without cadence filtering. Must be a positive integer when provided.
         include_all_fields: If True, include additional and custom fields beyond the standard set (optional, defaults to False)
     """
     athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
@@ -65,7 +66,7 @@ async def get_wellness_data(
 
     # Validate cadence parameter
     if cadence and cadence < 1:
-        return "Cadence must be a positive integer (1 or greater)."
+        return "Cadence must be a positive integer (1 or greater) when provided. Use 0 to disable cadence filtering."
 
     # Call the Intervals.icu API
     params = {"oldest": start_date, "newest": end_date}

--- a/src/intervals_mcp_server/tools/wellness.py
+++ b/src/intervals_mcp_server/tools/wellness.py
@@ -20,12 +20,12 @@ config = get_config()
 
 @mcp.tool()
 async def get_wellness_data(
-    athlete_id: str | None = None,
-    api_key: str | None = None,
-    start_date: str | None = None,
-    end_date: str | None = None,
+    athlete_id: str = "",
+    api_key: str = "",
+    start_date: str = "",
+    end_date: str = "",
     fields: list[str] | None = None,
-    cadence: int | None = None,
+    cadence: int = 0,
     include_all_fields: bool = False,
 ) -> str:
     """Get wellness data for an athlete from Intervals.icu.
@@ -64,7 +64,7 @@ async def get_wellness_data(
         fields_set = set(fields)
 
     # Validate cadence parameter
-    if cadence is not None and cadence < 1:
+    if cadence and cadence < 1:
         return "Cadence must be a positive integer (1 or greater)."
 
     # Call the Intervals.icu API
@@ -94,7 +94,7 @@ async def get_wellness_data(
         entries = [e for e in result if isinstance(e, dict)]
 
     # Apply cadence filtering (keep every Nth entry)
-    if cadence is not None and cadence > 1:
+    if cadence and cadence > 1:
         entries = entries[::cadence]
 
     wellness_summary = "Wellness Data:\n\n"

--- a/src/intervals_mcp_server/utils/validation.py
+++ b/src/intervals_mcp_server/utils/validation.py
@@ -54,14 +54,14 @@ def resolve_athlete_id(
 
     Args:
         athlete_id: Optional athlete ID parameter.
-        default_athlete_id: Default athlete ID to use if athlete_id is None.
+        default_athlete_id: Default athlete ID to use if athlete_id is None or empty.
 
     Returns:
         Tuple of (athlete_id_to_use, error_message).
         athlete_id_to_use will be empty string if not found.
         error_message will be None if athlete_id is resolved successfully.
     """
-    athlete_id_to_use = athlete_id if athlete_id is not None else default_athlete_id
+    athlete_id_to_use = athlete_id if athlete_id else default_athlete_id
     if not athlete_id_to_use:
         return (
             "",

--- a/tests/test_activities_date_filter.py
+++ b/tests/test_activities_date_filter.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for activity date filtering in intervals_mcp_server.tools.activities.
+"""
+
+import asyncio
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+os.environ.setdefault("API_KEY", "test")
+os.environ.setdefault("ATHLETE_ID", "i1")
+
+from intervals_mcp_server.tools.activities import _filter_activities_by_date
+from intervals_mcp_server.server import get_activities
+
+
+def test_filter_activities_by_date_includes_matching():
+    activities = [
+        {"name": "Ride", "startTime": "2024-03-15T08:00:00Z"},
+        {"name": "Run", "startTime": "2024-03-16T07:00:00Z"},
+    ]
+    result = _filter_activities_by_date(activities, "2024-03-15", "2024-03-16")
+    assert len(result) == 2
+
+
+def test_filter_activities_by_date_excludes_outside_range():
+    activities = [
+        {"name": "Ride", "startTime": "2024-03-10T08:00:00Z"},
+        {"name": "Run", "startTime": "2024-03-15T07:00:00Z"},
+        {"name": "Swim", "startTime": "2024-03-20T06:00:00Z"},
+    ]
+    result = _filter_activities_by_date(activities, "2024-03-14", "2024-03-16")
+    assert len(result) == 1
+    assert result[0]["name"] == "Run"
+
+
+def test_filter_activities_by_date_single_day():
+    activities = [
+        {"name": "Ride", "startTime": "2024-04-01T08:00:00Z"},
+        {"name": "Run", "startTime": "2024-04-02T07:00:00Z"},
+        {"name": "Swim", "startTime": "2024-04-03T06:00:00Z"},
+    ]
+    result = _filter_activities_by_date(activities, "2024-04-02", "2024-04-02")
+    assert len(result) == 1
+    assert result[0]["name"] == "Run"
+
+
+def test_filter_activities_by_date_uses_start_date_local():
+    activities = [
+        {"name": "Ride", "start_date_local": "2024-05-01T08:00:00"},
+        {"name": "Run", "start_date_local": "2024-05-05T07:00:00"},
+    ]
+    result = _filter_activities_by_date(activities, "2024-05-01", "2024-05-03")
+    assert len(result) == 1
+    assert result[0]["name"] == "Ride"
+
+
+def test_filter_activities_by_date_skips_no_date():
+    activities = [
+        {"name": "Ride"},
+        {"name": "Run", "startTime": "2024-03-15T07:00:00Z"},
+    ]
+    result = _filter_activities_by_date(activities, "2024-03-01", "2024-03-31")
+    assert len(result) == 1
+    assert result[0]["name"] == "Run"
+
+
+def test_get_activities_filters_by_date(monkeypatch):
+    """End-to-end: only activities within the requested dates are returned."""
+    sample_activities = [
+        {"name": "In Range", "id": 1, "type": "Ride", "startTime": "2024-06-15T08:00:00Z", "distance": 100, "duration": 60},
+        {"name": "Out of Range", "id": 2, "type": "Run", "startTime": "2024-06-10T07:00:00Z", "distance": 50, "duration": 30},
+    ]
+
+    async def fake_request(*_args, **_kwargs):
+        return sample_activities
+
+    monkeypatch.setattr("intervals_mcp_server.tools.activities.make_intervals_request", fake_request)
+
+    result = asyncio.run(
+        get_activities(athlete_id="1", start_date="2024-06-14", end_date="2024-06-16", limit=10, include_unnamed=True)
+    )
+    assert "In Range" in result
+    assert "Out of Range" not in result
+
+
+def test_get_activities_no_results_when_all_outside_range(monkeypatch):
+    """When all API results are outside the date range, return 'no activities' message."""
+    sample_activities = [
+        {"name": "Old Ride", "id": 1, "type": "Ride", "startTime": "2024-01-01T08:00:00Z", "distance": 100, "duration": 60},
+    ]
+
+    async def fake_request(*_args, **_kwargs):
+        return sample_activities
+
+    monkeypatch.setattr("intervals_mcp_server.tools.activities.make_intervals_request", fake_request)
+
+    result = asyncio.run(
+        get_activities(athlete_id="1", start_date="2024-06-01", end_date="2024-06-30", limit=10, include_unnamed=True)
+    )
+    assert "No" in result and "activities" in result.lower()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -69,7 +69,7 @@ def test_get_activities(monkeypatch):
     monkeypatch.setattr(
         "intervals_mcp_server.tools.activities.make_intervals_request", fake_request
     )
-    result = asyncio.run(get_activities(athlete_id="1", limit=1, include_unnamed=True))
+    result = asyncio.run(get_activities(athlete_id="1", start_date="2024-01-01", end_date="2024-01-01", limit=1, include_unnamed=True))
     assert "Morning Ride" in result
     assert "Activities:" in result
 
@@ -305,7 +305,7 @@ def test_get_wellness_data_cadence_invalid(monkeypatch):
     """
     Test that cadence < 1 returns an error message.
     """
-    result = asyncio.run(get_wellness_data(athlete_id="1", cadence=0))
+    result = asyncio.run(get_wellness_data(athlete_id="1", cadence=-1))
     assert "Cadence must be a positive integer" in result
 
 
@@ -1166,7 +1166,7 @@ def test_get_athlete_zones_no_athlete_id(monkeypatch):
     config_module._config_instance = config_module.load_config()
 
     try:
-        result = asyncio.run(get_athlete_zones(athlete_id=None))
+        result = asyncio.run(get_athlete_zones(athlete_id=""))
         assert "Error" in result or "No athlete ID" in result
     finally:
         config_module._config_instance = original


### PR DESCRIPTION
- [x] Updated cadence docstring and validation in wellness.py
- [x] Fix `_filter_activities_by_date()` to use `datetime.strptime` parsing instead of lexicographic string comparison
- [x] Document `moving_time=0`/`distance=0` sentinel behavior in events.py docstring
- [x] All 168 tests pass, ruff clean